### PR TITLE
fix : path to form template

### DIFF
--- a/src/Controller/Admin/DefaultAdminController.php
+++ b/src/Controller/Admin/DefaultAdminController.php
@@ -133,7 +133,7 @@ class DefaultAdminController extends AbstractController
         }
         // Example: Generating a URL for the route using Symfony's router
         $url = $this->generateUrl('skynettechnologies_sylius_allinoneaccessibility_plugin_admin_allinoneaccessibility_create', ['page' => $page]);
-        return $this->render('@SkynettechnologiesSyliusAllinOneAccessibilityPlugin/admin/AllinOneAccessibility/_form.html.twig', [
+        return $this->render('@SkynettechnologiesSyliusAllinOneAccessibilityPlugin/Admin/AllinOneAccessibility/_form.html.twig', [
             'url' => $url,  // Pass the generated URL to the template
             'page' => $page,
             'domain' => $domain,


### PR DESCRIPTION
This is an easy fix @skynetindia 
The path miss a capitalized A to fit the right path of the template.